### PR TITLE
Fix iOS unexpected tooltip destroy

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/tooltip-area.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/tooltip-area.component.ts
@@ -18,6 +18,7 @@ import { isPlatformBrowser } from '@angular/common';
   template: `
     <svg:g>
       <svg:rect
+        #tooltipArea
         class="tooltip-area"
         [attr.x]="0"
         y="0"
@@ -53,6 +54,7 @@ import { isPlatformBrowser } from '@angular/common';
         [tooltipTemplate]="tooltipTemplate ? tooltipTemplate : defaultTooltipTemplate"
         [tooltipContext]="anchorValues"
         [tooltipImmediateExit]="true"
+        [tooltipArea]="tooltipArea"
       />
     </svg:g>
   `,

--- a/projects/swimlane/ngx-charts/src/lib/common/tooltip/tooltip.directive.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/tooltip/tooltip.directive.ts
@@ -6,7 +6,7 @@ import {
   HostListener,
   ViewContainerRef,
   Renderer2,
-  OnDestroy
+  OnDestroy,
 } from '@angular/core';
 
 import { PlacementTypes } from './position';
@@ -35,6 +35,7 @@ export class TooltipDirective implements OnDestroy {
   @Input() tooltipShowEvent: ShowTypes = ShowTypes.all;
   @Input() tooltipContext: any;
   @Input() tooltipImmediateExit: boolean = false;
+  @Input() tooltipArea: any;
 
   @Output() show = new EventEmitter();
   @Output() hide = new EventEmitter();
@@ -146,9 +147,10 @@ export class TooltipDirective implements OnDestroy {
 
     // content close on click outside
     if (this.tooltipCloseOnClickOutside) {
-      this.documentClickEvent = this.renderer.listen('window', 'click', event => {
-        const contains = tooltip.contains(event.target);
-        if (!contains) this.hideTooltip();
+      this.documentClickEvent = this.renderer.listen('window', 'click', ({ target} ) => {
+        if (this.tooltipArea !== target && !tooltip.contains(target)) {
+          this.hideTooltip();
+        }
       });
     }
   }

--- a/projects/swimlane/ngx-charts/src/lib/common/tooltip/tooltip.directive.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/tooltip/tooltip.directive.ts
@@ -147,7 +147,7 @@ export class TooltipDirective implements OnDestroy {
 
     // content close on click outside
     if (this.tooltipCloseOnClickOutside) {
-      this.documentClickEvent = this.renderer.listen('window', 'click', ({ target} ) => {
+      this.documentClickEvent = this.renderer.listen('window', 'click', ({ target }) => {
         if (this.tooltipArea !== target && !tooltip.contains(target)) {
           this.hideTooltip();
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

[Safari, iOS 14.4, iPadOS 14.5) The tooltip automatically disappears after the user's touch.

**What is the new behavior?**

The tooltip directive receives the tooltip area reference as an Input parameter. The `documentClickEvent` uses this reference as an exception for the click handler.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ x ] No
